### PR TITLE
Stern: BC1/DXT1 (fmt=4) texture support + Spine export

### DIFF
--- a/installer/build_linux.sh
+++ b/installer/build_linux.sh
@@ -68,6 +68,7 @@ pyinstaller \
     --hidden-import "pinball_decryptor.plugins.stern.rawdevice" \
     --hidden-import "pinball_decryptor.plugins.stern.radium" \
     --hidden-import "pinball_decryptor.plugins.stern.dds" \
+    --hidden-import "pinball_decryptor.plugins.stern.spine" \
     --hidden-import "pinball_decryptor.plugins.stern.spike2" \
     --hidden-import "pinball_decryptor.plugins.stern.spike2.elf" \
     --hidden-import "pinball_decryptor.plugins.stern.spike2.rbtree" \

--- a/installer/build_macos.sh
+++ b/installer/build_macos.sh
@@ -87,6 +87,7 @@ pyinstaller \
     --hidden-import "pinball_decryptor.plugins.stern.rawdevice" \
     --hidden-import "pinball_decryptor.plugins.stern.radium" \
     --hidden-import "pinball_decryptor.plugins.stern.dds" \
+    --hidden-import "pinball_decryptor.plugins.stern.spine" \
     --hidden-import "pinball_decryptor.plugins.stern.spike2" \
     --hidden-import "pinball_decryptor.plugins.stern.spike2.elf" \
     --hidden-import "pinball_decryptor.plugins.stern.spike2.rbtree" \

--- a/pinball_decryptor/plugins/stern/dds.py
+++ b/pinball_decryptor/plugins/stern/dds.py
@@ -17,6 +17,13 @@ BC3 layout (16 bytes / 4×4 block): bytes 0-7 = alpha block (a0, a1, then 16×
 3-bit indices, LSB-first); bytes 8-15 = colour block (RGB565 c0, c1, then 16×
 2-bit indices).  BC3's colour block is **always** decoded in 4-colour mode
 regardless of the c0/c1 ordering (unlike BC1).
+
+Spike 2 also ships some textures as **BC1/DXT1** (the radium descriptor's
+``format`` enum ``4``): 8 bytes / 4×4 block, half the size of BC3.  BC1's colour
+block is mode-switched on the c0/c1 ordering — ``c0 > c1`` ⇒ 4-colour opaque,
+``c0 <= c1`` ⇒ 3-colour + 1-bit punch-through alpha (index 3 = transparent
+black).  :func:`decode_bc1` / :func:`encode_bc1` handle both modes and are
+size-neutral by construction just like the BC3 pair.
 """
 
 import struct
@@ -110,6 +117,60 @@ def decode_bc3(raw, width, height):
     return img[:height, :width].copy()
 
 
+def decode_bc1(raw, width, height):
+    """Decode raw BC1/DXT1 block bytes to an ``(height, width, 4)`` uint8 RGBA
+    array.  ``len(raw)`` must be ``ceil(w/4)*ceil(h/4)*8``.
+
+    Mode is per-block: ``c0 > c1`` ⇒ 4-colour opaque palette; ``c0 <= c1`` ⇒
+    3-colour palette + index 3 = transparent black (1-bit punch-through alpha)."""
+    bx = (width + 3) // 4
+    by = (height + 3) // 4
+    nb = bx * by
+    need = nb * 8
+    if len(raw) < need:
+        raise ValueError("BC1 data too short: have %d, need %d (%dx%d)"
+                         % (len(raw), need, width, height))
+    d = np.frombuffer(raw[:need], dtype=np.uint8).reshape(nb, 8).astype(np.int32)
+
+    c0 = (d[:, 0] | (d[:, 1] << 8)).astype(np.uint16)
+    c1 = (d[:, 2] | (d[:, 3] << 8)).astype(np.uint16)
+    r0, g0, b0 = _unpack565(c0)
+    r1, g1, b1 = _unpack565(c1)
+    four = (c0 > c1)[:, None]                                   # 4-colour mode
+    # palette entry 2/3 differ per mode; 0/1 are the endpoints either way
+    cR = np.stack([r0, r1,
+                   np.where(four[:, 0], (2 * r0 + r1) // 3, (r0 + r1) // 2),
+                   np.where(four[:, 0], (r0 + 2 * r1) // 3, 0)], axis=1)
+    cG = np.stack([g0, g1,
+                   np.where(four[:, 0], (2 * g0 + g1) // 3, (g0 + g1) // 2),
+                   np.where(four[:, 0], (g0 + 2 * g1) // 3, 0)], axis=1)
+    cB = np.stack([b0, b1,
+                   np.where(four[:, 0], (2 * b0 + b1) // 3, (b0 + b1) // 2),
+                   np.where(four[:, 0], (b0 + 2 * b1) // 3, 0)], axis=1)
+    # alpha palette: opaque for 0/1/2; index 3 transparent only in 3-colour mode
+    aP = np.where(four, np.uint16(255), np.uint16(255)).repeat(4, axis=1).astype(np.int32)
+    aP[:, 3] = np.where(four[:, 0], 255, 0)
+
+    cbits = (d[:, 4] | (d[:, 5] << 8)
+             | (d[:, 6] << 16) | (d[:, 7] << 24)).astype(np.uint32)
+    c_ind = np.empty((nb, 16), dtype=np.int64)
+    for t in range(16):
+        c_ind[:, t] = (cbits >> np.uint32(2 * t)) & np.uint32(3)
+    R = np.take_along_axis(cR, c_ind, axis=1)
+    G = np.take_along_axis(cG, c_ind, axis=1)
+    B = np.take_along_axis(cB, c_ind, axis=1)
+    A = np.take_along_axis(aP, c_ind, axis=1)
+
+    px = np.empty((nb, 16, 4), dtype=np.uint8)
+    px[:, :, 0] = R
+    px[:, :, 1] = G
+    px[:, :, 2] = B
+    px[:, :, 3] = A.astype(np.uint8)
+    block = px.reshape(by, bx, 4, 4, 4)
+    img = block.transpose(0, 2, 1, 3, 4).reshape(by * 4, bx * 4, 4)
+    return img[:height, :width].copy()
+
+
 # --------------------------------------------------------------------------
 # Encode (range-fit: simple, correct, fast)
 # --------------------------------------------------------------------------
@@ -191,6 +252,80 @@ def encode_bc3(rgba):
     for i in range(4):
         out[:, 12 + i] = ((cbits >> np.uint32(8 * i)) & np.uint32(0xFF)).astype(np.uint8)
 
+    return out.tobytes()
+
+
+def encode_bc1(rgba):
+    """Encode an ``(h, w, 4)`` uint8 RGBA array to raw BC1/DXT1 block bytes.
+
+    Per block: if every texel is opaque (alpha >= 128) it uses the 4-colour
+    opaque mode (``c0 > c1``); otherwise it uses the 3-colour punch-through mode
+    (``c0 <= c1``) with transparent texels (alpha < 128) mapped to index 3.
+    Bounding-box endpoints, nearest-palette indices — deterministic, not
+    rate-distortion optimal.  Output length is exactly ``ceil(w/4)*ceil(h/4)*8``
+    (half of BC3), the size-neutral property the in-place patcher relies on."""
+    rgba = np.asarray(rgba, dtype=np.uint8)
+    h, w, ch = rgba.shape
+    if ch != 4:
+        raise ValueError("encode_bc1 needs RGBA (h,w,4)")
+    bx = (w + 3) // 4
+    by = (h + 3) // 4
+    ph, pw = by * 4, bx * 4
+    if (ph, pw) != (h, w):
+        pad = np.zeros((ph, pw, 4), dtype=np.uint8)
+        pad[:h, :w] = rgba
+        if pw > w:
+            pad[:h, w:] = rgba[:, w - 1:w]
+        if ph > h:
+            pad[h:, :] = pad[h - 1:h, :]
+        rgba = pad
+    blocks = rgba.reshape(by, 4, bx, 4, 4).transpose(0, 2, 1, 3, 4)
+    nb = by * bx
+    blocks = blocks.reshape(nb, 16, 4).astype(np.int32)
+    R = blocks[:, :, 0]
+    G = blocks[:, :, 1]
+    B = blocks[:, :, 2]
+    A = blocks[:, :, 3]
+    out = np.zeros((nb, 8), dtype=np.uint8)
+
+    transp = A < 128                                   # (nb,16) punch-through
+    has_alpha = transp.any(axis=1)                     # (nb,) -> 3-colour mode
+    # bounding box over RGB (max corner packs >= min corner, monotone per field)
+    hi = _pack565(R.max(axis=1), G.max(axis=1), B.max(axis=1))
+    lo = _pack565(R.min(axis=1), G.min(axis=1), B.min(axis=1))
+    # 4-colour opaque wants c0 > c1 (= hi, lo); 3-colour wants c0 <= c1 (= lo, hi)
+    c0 = np.where(has_alpha, lo, hi).astype(np.uint16)
+    c1 = np.where(has_alpha, hi, lo).astype(np.uint16)
+    four = (c0 > c1)                                    # matches decoder's test
+    r0, g0, b0 = _unpack565(c0)
+    r1, g1, b1 = _unpack565(c1)
+    f = four[:, None]
+    cR = np.stack([r0, r1,
+                   np.where(four, (2 * r0 + r1) // 3, (r0 + r1) // 2),
+                   np.where(four, (r0 + 2 * r1) // 3, 0)], axis=1)
+    cG = np.stack([g0, g1,
+                   np.where(four, (2 * g0 + g1) // 3, (g0 + g1) // 2),
+                   np.where(four, (g0 + 2 * g1) // 3, 0)], axis=1)
+    cB = np.stack([b0, b1,
+                   np.where(four, (2 * b0 + b1) // 3, (b0 + b1) // 2),
+                   np.where(four, (b0 + 2 * b1) // 3, 0)], axis=1)
+    dist = ((R[:, :, None] - cR[:, None, :]) ** 2
+            + (G[:, :, None] - cG[:, None, :]) ** 2
+            + (B[:, :, None] - cB[:, None, :]) ** 2).astype(np.int64)
+    # in 3-colour blocks index 3 is transparent: forbid it for opaque texels
+    forbid3 = (~f) & (~transp)                          # (nb,16)
+    dist[:, :, 3] = np.where(forbid3, np.int64(1) << 40, dist[:, :, 3])
+    c_ind = dist.argmin(axis=2).astype(np.uint32)
+    c_ind = np.where(transp, np.uint32(3), c_ind)       # transparent -> index 3
+    cbits = np.zeros(nb, dtype=np.uint32)
+    for t in range(16):
+        cbits |= (c_ind[:, t] & np.uint32(3)) << np.uint32(2 * t)
+    out[:, 0] = (c0 & 0xFF).astype(np.uint8)
+    out[:, 1] = (c0 >> 8).astype(np.uint8)
+    out[:, 2] = (c1 & 0xFF).astype(np.uint8)
+    out[:, 3] = (c1 >> 8).astype(np.uint8)
+    for i in range(4):
+        out[:, 4 + i] = ((cbits >> np.uint32(8 * i)) & np.uint32(0xFF)).astype(np.uint8)
     return out.tobytes()
 
 

--- a/pinball_decryptor/plugins/stern/engine.py
+++ b/pinball_decryptor/plugins/stern/engine.py
@@ -293,6 +293,7 @@ def extract_images(reader, output_dir, log=None, progress=None, cancel=None):
 _TEXTURE_MANIFEST = "manifest.txt"
 _TEXTURE_DIR = ("images", "scene_textures")
 _DXT5_FORMAT = 5            # the radium texture-descriptor format enum for BC3
+_DXT1_FORMAT = 4            # the radium texture-descriptor format enum for BC1
 
 
 def parse_texture_descriptor(radium, ref):
@@ -318,12 +319,13 @@ def parse_texture_descriptor(radium, ref):
 
 def extract_scene_textures(reader, output_dir, log=None, progress=None,
                            cancel=None):
-    """Decode every BC3/DXT5 scene texture to ``output_dir/images/scene_textures/``
-    as RGBA PNG.
+    """Decode every BC3/DXT5 or BC1/DXT1 scene texture to
+    ``output_dir/images/scene_textures/`` as RGBA PNG.
 
     These are the single (non-nested, non-``ftyp``) ``scene.assets/<N>.asset``
-    files — raw BC3 block data whose width/height/format are read from the
-    co-located ``scene.radium`` (:func:`parse_texture_descriptor`).  A
+    files — raw BC3 (``format==5``) or BC1 (``format==4``) block data whose
+    width/height/format are read from the co-located ``scene.radium``
+    (:func:`parse_texture_descriptor`).  A
     ``manifest.txt`` records ``output -> card path, bytes, w, h, format`` so Write
     can re-encode an edited PNG back to the exact original slot."""
     log = log or (lambda *a, **k: None)
@@ -387,13 +389,20 @@ def extract_scene_textures(reader, output_dir, log=None, progress=None,
             continue
         w, h, fmt = desc
         size = node["size"]
-        # Only BC3/DXT5 (1 byte/pixel) is supported so far; the size guard also
-        # rejects a descriptor that didn't really belong to this asset.
-        if fmt != _DXT5_FORMAT or w * h != size:
+        # BC3/DXT5 (16 B/4×4 block) and BC1/DXT1 (8 B/4×4 block) are supported.
+        # The block-padded size is the exact, dimension-correct law (a texture
+        # whose W/H aren't multiples of 4 still occupies whole 4×4 blocks); it
+        # doubles as a guard that the descriptor really belongs to this asset.
+        nblk = ((w + 3) // 4) * ((h + 3) // 4)
+        if fmt == _DXT5_FORMAT and size == nblk * 16:
+            decode = _dds.decode_bc3
+        elif fmt == _DXT1_FORMAT and size == nblk * 8:
+            decode = _dds.decode_bc1
+        else:
             n_skip += 1
             continue
         try:
-            rgba = _dds.decode_bc3(reader.read_file_bytes(node), w, h)
+            rgba = decode(reader.read_file_bytes(node), w, h)
             im = Image.fromarray(rgba, "RGBA")
         except Exception as e:
             log("Texture %s: decode failed (%s); skipped." % (ref, e), "warning")
@@ -464,43 +473,49 @@ def _nearest_element_name(data, before_off, window=512):
 
 
 def parse_radium_images(data):
-    """Find every inline BC3/DXT5 image in a ``scene.radium``.
+    """Find every inline BC3/DXT5 or BC1/DXT1 image in a ``scene.radium``.
 
     Each image is serialized as
-    ``[dispW u32][dispH u32][handle u32][texW u32][texH u32][format u32=5]
-    [0 u32][0 u32][length u32][BC3 data]`` where
-    ``length == padded4(texW) * padded4(texH)`` (BC3 = 1 byte/pixel).  We anchor
-    on the ``format=5, 0, 0`` triplet and validate that the length matches the
-    block-padded dimensions and that the data fits — a signature specific enough
-    to have no false positives.
+    ``[dispW u32][dispH u32][handle u32][texW u32][texH u32][format u32]
+    [0 u32][0 u32][length u32][block data]`` where
+    ``length == padded4(texW) * padded4(texH)`` for BC3 (``format==5``,
+    1 byte/pixel) or half that for BC1 (``format==4``, 1/2 byte/pixel).  We anchor
+    on the ``format, 0, 0`` triplet and validate that the length matches the
+    block-padded dimensions for that format and that the data fits — a signature
+    specific enough to have no false positives.
 
-    Returns ``[{data_off, length, tex_w, tex_h, pad_w, pad_h, disp_w, disp_h}]``
-    where decoding uses ``pad_w x pad_h`` (the full BC3 grid)."""
+    Returns ``[{data_off, length, fmt, tex_w, tex_h, pad_w, pad_h, disp_w,
+    disp_h}]`` where decoding uses ``pad_w x pad_h`` (the full block grid)."""
     out = []
     n = len(data)
-    sig = b"\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"   # fmt=5, 0, 0
-    i = data.find(sig)
-    while i >= 0:
-        m = i
-        i = data.find(sig, i + 1)
-        if m < 8 or m + 16 > n:
-            continue
-        tex_w = struct.unpack_from("<I", data, m - 8)[0]
-        tex_h = struct.unpack_from("<I", data, m - 4)[0]
-        if not (0 < tex_w <= 8192 and 0 < tex_h <= 8192):
-            continue
-        length = struct.unpack_from("<I", data, m + 12)[0]
-        pad_w, pad_h = _padded4(tex_w), _padded4(tex_h)
-        if length != pad_w * pad_h or m + 16 + length > n:
-            continue
-        disp_w = struct.unpack_from("<I", data, m - 20)[0] if m >= 20 else tex_w
-        disp_h = struct.unpack_from("<I", data, m - 16)[0] if m >= 20 else tex_h
-        if not (0 < disp_w <= pad_w):
-            disp_w = tex_w
-        if not (0 < disp_h <= pad_h):
-            disp_h = tex_h
-        out.append(dict(data_off=m + 16, length=length, tex_w=tex_w, tex_h=tex_h,
-                        pad_w=pad_w, pad_h=pad_h, disp_w=disp_w, disp_h=disp_h))
+    # fmt enum byte, then "0,0" (the two trailing u32s) -> 12-byte anchor
+    sigs = ((_DXT5_FORMAT, b"\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"),
+            (_DXT1_FORMAT, b"\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"))
+    for fmt, sig in sigs:
+        i = data.find(sig)
+        while i >= 0:
+            m = i
+            i = data.find(sig, i + 1)
+            if m < 8 or m + 16 > n:
+                continue
+            tex_w = struct.unpack_from("<I", data, m - 8)[0]
+            tex_h = struct.unpack_from("<I", data, m - 4)[0]
+            if not (0 < tex_w <= 8192 and 0 < tex_h <= 8192):
+                continue
+            length = struct.unpack_from("<I", data, m + 12)[0]
+            pad_w, pad_h = _padded4(tex_w), _padded4(tex_h)
+            want = pad_w * pad_h if fmt == _DXT5_FORMAT else pad_w * pad_h // 2
+            if length != want or m + 16 + length > n:
+                continue
+            disp_w = struct.unpack_from("<I", data, m - 20)[0] if m >= 20 else tex_w
+            disp_h = struct.unpack_from("<I", data, m - 16)[0] if m >= 20 else tex_h
+            if not (0 < disp_w <= pad_w):
+                disp_w = tex_w
+            if not (0 < disp_h <= pad_h):
+                disp_h = tex_h
+            out.append(dict(data_off=m + 16, length=length, fmt=fmt,
+                            tex_w=tex_w, tex_h=tex_h, pad_w=pad_w, pad_h=pad_h,
+                            disp_w=disp_w, disp_h=disp_h))
     return out
 
 
@@ -558,7 +573,9 @@ def extract_radium_images(reader, output_dir, log=None, progress=None,
             out_rel = by_hash.get(h)
             if out_rel is None:
                 try:
-                    rgba = _dds.decode_bc3(raw, im["pad_w"], im["pad_h"])
+                    decode = (_dds.decode_bc1 if im["fmt"] == _DXT1_FORMAT
+                              else _dds.decode_bc3)
+                    rgba = decode(raw, im["pad_w"], im["pad_h"])
                     pic = Image.fromarray(rgba, "RGBA")
                 except Exception as e:
                     log("Radium image %s: decode failed (%s); skipped."
@@ -578,16 +595,16 @@ def extract_radium_images(reader, output_dir, log=None, progress=None,
                 pic.save(os.path.join(output_dir, "images", *out_rel.split("/")))
                 by_hash[h] = out_rel
                 n_unique += 1
-            manifest.append("%s\t%s\t%d\t%d\t%d\t%d"
+            manifest.append("%s\t%s\t%d\t%d\t%d\t%d\t%d"
                             % (out_rel, path, im["data_off"], im["length"],
-                               im["pad_w"], im["pad_h"]))
+                               im["pad_w"], im["pad_h"], im["fmt"]))
             n_occ += 1
     if not manifest:
         return 0
     try:
         with open(os.path.join(tex_dir, _RADIUM_IMAGE_MANIFEST), "w",
                   encoding="utf-8") as f:
-            f.write("# output\tradium card path\tdata offset\tlength\tpad_w\tpad_h\n"
+            f.write("# output\tradium card path\tdata offset\tlength\tpad_w\tpad_h\tfmt\n"
                     + "\n".join(manifest) + "\n")
     except Exception:
         pass
@@ -833,6 +850,20 @@ def extract_all(image_path, partitions, output_dir, log=None, progress=None,
             except Exception as e:
                 log("Radium-image extraction failed (%s); continuing." % e,
                     "warning")
+            if cancel():
+                return 0
+            # Spine skeletons embedded verbatim in scene.radium (the 2D
+            # skeletal-animation rigs) -> spine/*.json — own try/except so a
+            # skeleton hiccup never blocks the other media or audio.
+            try:
+                from . import spine as _spine
+                _spine.extract_spine(
+                    reader, output_dir, log=log,
+                    progress=(lambda c, t, d="": progress(
+                        15, 100, d)) if progress else None,
+                    cancel=cancel)
+            except Exception as e:
+                log("Spine extraction failed (%s); continuing." % e, "warning")
         if cancel():
             return 0
 
@@ -1608,7 +1639,9 @@ def _prepare_texture_patches(reader, texture_edits, log, cancel):
                 "warning")
             skipped += 1
             continue
-        payload = _dds.encode_bc3(np.asarray(im, dtype=np.uint8))
+        arr = np.asarray(im, dtype=np.uint8)
+        payload = (_dds.encode_bc1(arr) if fmt == _DXT1_FORMAT
+                   else _dds.encode_bc3(arr))
         if len(payload) != node["size"]:
             log("Texture %s: re-encoded to %d bytes but the slot is %d; skipped."
                 % (output, len(payload), node["size"]), "warning")
@@ -1622,8 +1655,9 @@ def _prepare_texture_patches(reader, texture_edits, log, cancel):
 
 def _changed_radium_images(assets_dir, baseline):
     """Return ``[(output, radium_card_path, staged, data_off, length, pad_w,
-    pad_h), ...]`` for the radium-embedded images whose PNG differs from the
-    Extract baseline.  Empty when there's no ``radium_images.txt`` manifest."""
+    pad_h, fmt), ...]`` for the radium-embedded images whose PNG differs from the
+    Extract baseline.  Empty when there's no ``radium_images.txt`` manifest.
+    ``fmt`` defaults to BC3/DXT5 for manifests written before the BC1 column."""
     from ...core.checksums import md5_file
     tex_dir = os.path.join(assets_dir, *_TEXTURE_DIR)
     manifest = os.path.join(tex_dir, _RADIUM_IMAGE_MANIFEST)
@@ -1642,6 +1676,7 @@ def _changed_radium_images(assets_dir, baseline):
             try:
                 data_off, length = int(cols[2]), int(cols[3])
                 pad_w, pad_h = int(cols[4]), int(cols[5])
+                fmt = int(cols[6]) if len(cols) > 6 else _DXT5_FORMAT
             except ValueError:
                 continue
             staged = os.path.join(assets_dir, "images", *output.split("/"))
@@ -1654,17 +1689,18 @@ def _changed_radium_images(assets_dir, baseline):
             except OSError:
                 pass
             out.append((output, radium_path, staged, data_off, length,
-                        pad_w, pad_h))
+                        pad_w, pad_h, fmt))
     return out
 
 
 def _radium_image_writes(reader, assets_dir, baseline, log, cancel):
-    """Re-encode each edited radium-embedded image to BC3 and resolve it to a
-    flat ``[(disk_offset, bytes), ...]`` list patching the bytes in place inside
-    the ``scene.radium`` inode (same form ``_compute_patches`` collects, like the
-    display-text writes).  Returns ``(writes, n_images)``.
+    """Re-encode each edited radium-embedded image to its format (BC3/DXT5 or
+    BC1/DXT1) and resolve it to a flat ``[(disk_offset, bytes), ...]`` list
+    patching the bytes in place inside the ``scene.radium`` inode (same form
+    ``_compute_patches`` collects, like the display-text writes).  Returns
+    ``(writes, n_images)``.
 
-    Size-neutral by construction: the PNG is the full padded BC3 grid, so
+    Size-neutral by construction: the PNG is the full padded block grid, so
     re-encoding yields exactly ``length`` bytes at ``data_offset``."""
     edits = _changed_radium_images(assets_dir, baseline)
     if not edits:
@@ -1680,9 +1716,9 @@ def _radium_image_writes(reader, assets_dir, baseline, log, cancel):
     nodes = _resolve_card_nodes(
         reader, list({rp for (_o, rp, *_r) in edits}), cancel)
     writes = []
-    encoded = {}                   # staged PNG path -> BC3 bytes (one PNG, many occurrences)
+    encoded = {}                   # staged PNG path -> block bytes (one PNG, many occurrences)
     patched_outputs = set()
-    for output, radium_path, staged, data_off, length, pad_w, pad_h in edits:
+    for output, radium_path, staged, data_off, length, pad_w, pad_h, fmt in edits:
         if cancel():
             break
         node = nodes.get(radium_path)
@@ -1703,7 +1739,9 @@ def _radium_image_writes(reader, assets_dir, baseline, log, cancel):
                     "(don't resize — edit in place)."
                     % (output, im.size[0], im.size[1], pad_w, pad_h), "warning")
                 continue
-            payload = _dds.encode_bc3(np.asarray(im, dtype=np.uint8))
+            arr = np.asarray(im, dtype=np.uint8)
+            payload = (_dds.encode_bc1(arr) if fmt == _DXT1_FORMAT
+                       else _dds.encode_bc3(arr))
             encoded[staged] = payload
         if len(payload) != length:
             log("Radium image %s: re-encoded to %d bytes but the slot is %d; "

--- a/pinball_decryptor/plugins/stern/spine.py
+++ b/pinball_decryptor/plugins/stern/spine.py
@@ -1,0 +1,201 @@
+"""Stern Spike 2 Spine skeleton export.
+
+Spine scenes (radium element type ``"Spine"``) embed a complete Spine 3.1
+skeleton as a plain-JSON, u64-length-prefixed string inside ``scene.radium``:
+
+    {"skeleton":{"hash":"...","spine":"3.1.08","width":...,"height":...},
+     "bones":[...],"slots":[...],"skins":{...},"animations":{...}}
+
+The JSON is written out **verbatim** (a byte-exact slice of the radium); no
+transform is applied.  Reverse-engineered offline; validated 14 skeletons /
+698 animations on Elvira.
+
+Alongside each skeleton we emit a ``*.atlas.json`` attachment manifest
+(:func:`build_atlas`): every skin/slot/attachment with its declared geometry,
+plus the animation list.  IMPORTANT (empirically verified): the Spine
+attachment frames are **not** the loose fmt4/fmt5 texture leaves -- Spine scenes
+have no ``scene.assets`` and no ``<N>.asset`` records at all.  Each skeleton's
+frame pixels are embedded inside its own multi-MB ``scene.radium`` in a custom,
+not-yet-decoded frame format, so the atlas maps attachments to geometry, not to
+PNG files (honest provenance is recorded in the ``frame_source`` field).
+
+Upstream-plugin port of the standalone ``export_spine.py`` RE script: the
+skeleton scan + verbatim emit are byte-identical; only the I/O is adapted to
+read radium files through the pure-Python ext4 reader (:mod:`.ext4`).
+"""
+
+import json
+import os
+import struct
+
+# Spine JSON blobs can be large; the LP-string scan must allow well past 64 KiB
+# (real skeletons reach a few MiB once animation curves are inlined).
+_MAX_LP = 16 << 20
+_GROUP_PREFIXES = ("spine", "video", "stream", "image", "texture")
+_SKELETON_MAGIC = b'{"skeleton"'
+
+
+def _lp_strings(data, max_len=_MAX_LP):
+    """Yield ``(offset, bytes)`` for every printable u64-length-prefixed string."""
+    i, n = 0, len(data)
+    while i + 8 <= n:
+        ln = struct.unpack_from("<Q", data, i)[0]
+        if 1 <= ln <= max_len and i + 8 + ln <= n:
+            s = data[i + 8:i + 8 + ln]
+            if all(9 <= b < 127 for b in s):
+                yield i + 8, s
+                i += 8 + ln
+                continue
+        i += 1
+
+
+def _group_name(data):
+    """The scene group tag, e.g. ``'spine.Gargoyle'`` (first dotted token)."""
+    for _, s in _lp_strings(data, max_len=512):
+        t = s.decode("ascii", "replace")
+        if "." in t and t.split(".")[0] in _GROUP_PREFIXES:
+            return t
+    return None
+
+
+def extract_skeleton(data):
+    """Return ``(group, json_bytes)`` for a scene.radium blob, or ``None``.
+
+    Only blobs that actually contain a Spine skeleton (``{"skeleton"`` ... that
+    ``json.loads`` parses) are returned; everything else yields ``None``."""
+    if _SKELETON_MAGIC not in data:
+        return None
+    group = _group_name(data)
+    for _, s in _lp_strings(data):
+        if s[:len(_SKELETON_MAGIC)] == _SKELETON_MAGIC:
+            try:
+                json.loads(s.decode("utf-8"))
+            except Exception:                        # noqa: BLE001
+                continue
+            return group, s
+    return None
+
+
+def build_atlas(meta):
+    """Build an attachment/animation manifest from a parsed skeleton dict.
+
+    The Spine attachment frames for these scenes are NOT loose fmt4/fmt5 texture
+    leaves; each skeleton's frame pixels are embedded inside its own
+    ``scene.radium`` in a custom, as-yet-undecoded frame format.  So this maps
+    every attachment to the geometry the skeleton JSON declares, giving a
+    complete loadable index of the rig without claiming PNG links that don't
+    exist."""
+    skel = meta.get("skeleton", {}) or {}
+    attachments = []
+    for skin_name, slots in (meta.get("skins", {}) or {}).items():
+        if not isinstance(slots, dict):
+            continue
+        for slot_name, atts in slots.items():
+            if not isinstance(atts, dict):
+                continue
+            for att_name, adef in atts.items():
+                adef = adef or {}
+                attachments.append({
+                    "skin": skin_name, "slot": slot_name, "name": att_name,
+                    "type": adef.get("type", "region"),
+                    "w": adef.get("width"), "h": adef.get("height"),
+                    "path": adef.get("path"),
+                })
+    anims = meta.get("animations", {}) or {}
+    return {
+        "spine": skel.get("spine"),
+        "w": skel.get("width"), "h": skel.get("height"),
+        "bones": len(meta.get("bones", []) or []),
+        "slots": len(meta.get("slots", []) or []),
+        "skins": list((meta.get("skins", {}) or {}).keys()),
+        "animations": len(anims),
+        "animation_names": sorted(anims.keys()),
+        "frame_source": "scene.radium (embedded custom frame format, not decoded)",
+        "attachments": attachments,
+    }
+
+
+def _emit(out_dir, scene_hash, group, js, index):
+    g = (group or "spine.unknown").replace("/", "_")
+    base = "%s__%s" % (g, scene_hash)
+    cand, k = base, 0
+    while os.path.exists(os.path.join(out_dir, cand + ".json")):
+        k += 1
+        cand = "%s_%d" % (base, k)
+    with open(os.path.join(out_dir, cand + ".json"), "wb") as f:
+        f.write(js)                                  # byte-exact verbatim JSON
+    meta = json.loads(js.decode("utf-8"))
+    skel = meta.get("skeleton", {}) or {}
+    atlas = build_atlas(meta)
+    atlas["group"] = group
+    atlas["scene"] = scene_hash
+    atlas["json"] = cand + ".json"
+    with open(os.path.join(out_dir, cand + ".atlas.json"), "w") as f:
+        json.dump(atlas, f, indent=2)
+    index.append({
+        "group": group, "scene": scene_hash, "json": cand + ".json",
+        "atlas": cand + ".atlas.json",
+        "spine": skel.get("spine"), "w": skel.get("width"),
+        "h": skel.get("height"),
+        "bones": len(meta.get("bones", []) or []),
+        "slots": len(meta.get("slots", []) or []),
+        "animations": len(meta.get("animations", {}) or {}),
+        "attachments": len(atlas["attachments"]),
+    })
+
+
+# ---------------------------------------------------------------------------
+# extraction phase (reads radium through the ext4 reader)
+# ---------------------------------------------------------------------------
+def extract_spine(reader, output_dir, log=None, progress=None, cancel=None):
+    """Export every embedded Spine skeleton on the card to
+    ``output_dir/spine/`` (verbatim ``<group>__<scene>.json`` + ``.atlas.json``
+    + an ``index.json`` catalog).  Returns the number of skeletons exported."""
+    log = log or (lambda *a, **k: None)
+    cancel = cancel or (lambda: False)
+
+    log("Scanning .radium scene files for Spine skeletons...", "info")
+    rads = []
+    for path, _ino, node in reader.iter_regular_files(min_size=1):
+        if cancel():
+            return 0
+        if path.endswith("/scene.radium"):
+            rads.append((path, node))
+    if not rads:
+        log("No scene.radium files found.", "info")
+        return 0
+
+    out_dir = os.path.join(output_dir, "spine")
+    index, made = [], False
+    for i, (path, node) in enumerate(rads):
+        if cancel():
+            break
+        try:
+            data = reader.read_file_bytes(node)
+        except Exception:                            # noqa: BLE001
+            continue
+        res = extract_skeleton(data)
+        if res is None:
+            continue
+        if not made:
+            os.makedirs(out_dir, exist_ok=True)
+            made = True
+        group, js = res
+        scene_hash = path[:-len("/scene.radium")].rsplit("/", 1)[-1]
+        _emit(out_dir, scene_hash, group, js, index)
+        if progress:
+            progress(len(index), len(index), index[-1]["json"])
+
+    if not index:
+        log("No Spine skeletons found.", "info")
+        return 0
+    try:
+        with open(os.path.join(out_dir, "index.json"), "w") as f:
+            json.dump(index, f, indent=2)
+    except Exception:                                # noqa: BLE001
+        pass
+    n_anim = sum(e["animations"] for e in index)
+    n_att = sum(e.get("attachments", 0) for e in index)
+    log("Exported %d Spine skeleton(s) (%d animations, %d attachments) to %s."
+        % (len(index), n_anim, n_att, out_dir), "success")
+    return len(index)

--- a/tests/test_stern_dds.py
+++ b/tests/test_stern_dds.py
@@ -80,3 +80,68 @@ def test_from_dds_rejects_non_dxt5():
 def test_decode_rejects_short_data():
     with pytest.raises(ValueError):
         dds.decode_bc3(b"\x00" * 16, 512, 512)
+
+
+# --------------------------------------------------------------------------
+# BC1 / DXT1 (fmt == 4): 8 bytes / 4×4 block, half of BC3
+# --------------------------------------------------------------------------
+
+def test_bc1_encode_is_size_neutral():
+    for (h, w) in [(512, 512), (132, 132), (452, 400), (64, 64)]:
+        rgba = _checker(h, w)
+        rgba[..., 3] = 255                         # opaque -> 4-colour mode
+        raw = dds.encode_bc1(rgba)
+        blocks = ((w + 3) // 4) * ((h + 3) // 4)
+        assert len(raw) == blocks * 8              # half a byte/pixel for aligned dims
+        out = dds.decode_bc1(raw, w, h)
+        assert out.shape == (h, w, 4)
+
+
+def test_bc1_solid_colour_roundtrips_exactly():
+    img = np.empty((16, 16, 4), dtype=np.uint8)
+    img[:] = (40, 130, 200, 255)
+    out = dds.decode_bc1(dds.encode_bc1(img), 16, 16)
+    assert np.abs(out[..., :3].astype(int) - img[..., :3]).max() <= 8
+    assert (out[..., 3] == 255).all()
+
+
+def test_bc1_punch_through_alpha():
+    # 3-colour mode: transparent texels survive as index 3 (alpha 0).
+    img = np.zeros((8, 8, 4), dtype=np.uint8)
+    img[..., :3] = 100
+    img[..., 3] = 0                                # transparent left half
+    img[:, 4:, 3] = 255                            # opaque right half
+    out = dds.decode_bc1(dds.encode_bc1(img), 8, 8)
+    assert (out[:, :4, 3] == 0).all()
+    assert (out[:, 4:, 3] == 255).all()
+
+
+def test_bc1_opaque_block_has_no_transparent_texels():
+    # A fully-opaque, multi-colour block must use 4-colour mode (no false
+    # transparency from index 3).
+    img = _checker(16, 16)
+    img[..., 3] = 255
+    out = dds.decode_bc1(dds.encode_bc1(img), 16, 16)
+    assert (out[..., 3] == 255).all()
+
+
+def test_bc1_roundtrip_gradient_low_error():
+    img = _checker(64, 64)
+    img[..., 3] = 255                              # BC1 colour fidelity only
+    out = dds.decode_bc1(dds.encode_bc1(img), 64, 64)
+    rgb_err = np.abs(out[..., :3].astype(int) - img[..., :3]).mean()
+    assert rgb_err < 6.0
+
+
+def test_bc1_non_multiple_of_four_dims():
+    img = _checker(18, 30)
+    img[..., 3] = 255
+    raw = dds.encode_bc1(img)
+    assert len(raw) == (8 * 5) * 8                 # ceil(30/4)*ceil(18/4)*8
+    out = dds.decode_bc1(raw, 30, 18)
+    assert out.shape == (18, 30, 4)
+
+
+def test_bc1_decode_rejects_short_data():
+    with pytest.raises(ValueError):
+        dds.decode_bc1(b"\x00" * 8, 512, 512)

--- a/tests/test_stern_spine.py
+++ b/tests/test_stern_spine.py
@@ -1,0 +1,158 @@
+"""Tests for the Stern Spike 2 Spine exporter (``plugins/stern/spine.py``).
+
+* **Algorithmic parity** -- the ported skeleton scan + verbatim emit must match
+  the standalone RE script ``export_spine.py`` (validated 14 skel / 698 anim on
+  Elvira) byte-for-byte.  Skips when the script isn't present locally.
+* **Synthetic phase** -- ``extract_spine`` over a fake ext4 reader.
+"""
+
+import importlib.util
+import json
+import os
+import struct
+
+import pytest
+
+from pinball_decryptor.plugins.stern import spine
+
+_RE_SCRIPT = os.path.expanduser("~/Documents/stern/re_scratch/export_spine.py")
+
+
+def _load_re_script():
+    if not os.path.isfile(_RE_SCRIPT):
+        pytest.skip("RE cross-check script export_spine.py not present")
+    spec = importlib.util.spec_from_file_location("_re_export_spine", _RE_SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _lp(s):
+    if isinstance(s, str):
+        s = s.encode("ascii")
+    return struct.pack("<Q", len(s)) + s
+
+
+_SKEL = {
+    "skeleton": {"hash": "abc123", "spine": "3.1.08", "width": 200,
+                 "height": 100},
+    "bones": [{"name": "root"}, {"name": "b1"}],
+    "slots": [{"name": "s1", "bone": "root", "attachment": "a1"}],
+    "skins": {"default": {"s1": {"a1": {"width": 64, "height": 32}}}},
+    "animations": {"idle": {}, "walk": {}, "run": {}},
+}
+
+
+def _make_radium(skel=_SKEL, group="spine.Gargoyle"):
+    js = json.dumps(skel, separators=(",", ":")).encode("utf-8")
+    # group tag (short LP), then the skeleton JSON as a u64-LP string, embedded
+    # in some filler so offsets aren't trivially zero.
+    return (b"RADM" + _lp(group) + b"\x00" * 13 + _lp(js)
+            + b"\xff" * 9), js
+
+
+# --- skeleton scan --------------------------------------------------------
+
+def test_extract_skeleton_returns_group_and_verbatim_json():
+    data, js = _make_radium()
+    res = spine.extract_skeleton(data)
+    assert res is not None
+    group, out = res
+    assert group == "spine.Gargoyle"
+    assert out == js                     # byte-exact verbatim slice
+
+
+def test_extract_skeleton_none_without_magic():
+    assert spine.extract_skeleton(b"no skeleton here" * 10) is None
+
+
+def test_extract_skeleton_none_on_invalid_json():
+    # Has the magic but the LP body isn't valid JSON -> not returned.
+    bad = b'{"skeleton" but not json}'
+    data = b"X" + _lp(bad) + b"Y"
+    assert spine.extract_skeleton(data) is None
+
+
+def test_lp_scanner_handles_multimegabyte():
+    # A skeleton bigger than 64 KiB must still be found (max_len >= 16 MiB).
+    big = dict(_SKEL)
+    big["animations"] = {f"anim{i}": {"bones": {}} for i in range(4000)}
+    data, js = _make_radium(big)
+    assert len(js) > 70000
+    res = spine.extract_skeleton(data)
+    assert res is not None and res[1] == js
+
+
+def test_parity_with_re_script(tmp_path):
+    re = _load_re_script()
+    data, js = _make_radium()
+    rp = tmp_path / "scene.radium"
+    rp.write_bytes(data)
+    ref = re.extract_skeleton(str(rp))
+    mine = spine.extract_skeleton(data)
+    assert mine is not None and ref is not None
+    assert mine[0] == ref[0]             # same group
+    assert mine[1] == ref[1] == js       # byte-exact same JSON
+
+
+# --- atlas manifest -------------------------------------------------------
+
+def test_build_atlas_counts_and_attachments():
+    atlas = spine.build_atlas(_SKEL)
+    assert atlas["spine"] == "3.1.08"
+    assert atlas["bones"] == 2
+    assert atlas["slots"] == 1
+    assert atlas["animations"] == 3
+    assert atlas["animation_names"] == ["idle", "run", "walk"]
+    assert len(atlas["attachments"]) == 1
+    a = atlas["attachments"][0]
+    assert (a["skin"], a["slot"], a["name"]) == ("default", "s1", "a1")
+    assert a["w"] == 64 and a["h"] == 32
+    assert "not decoded" in atlas["frame_source"]
+
+
+# --- end-to-end phase -----------------------------------------------------
+
+class _FakeReader:
+    def __init__(self, files):
+        self._files = files
+
+    def iter_regular_files(self, min_size=1):
+        for path, data in self._files.items():
+            yield path, 0, {"size": len(data), "_data": data}
+
+    def read_file_bytes(self, node):
+        return node["_data"]
+
+
+def test_extract_spine_end_to_end(tmp_path):
+    data, js = _make_radium(group="spine.Gargoyle")
+    reader = _FakeReader({
+        "/g/spine/Gargoyle/scene.radium": data,
+        "/g/other/readme.txt": b"hello",
+    })
+    out = tmp_path / "out"
+    n = spine.extract_spine(reader, str(out))
+    assert n == 1
+    sp = out / "spine"
+    jsons = sorted(p.name for p in sp.glob("spine.Gargoyle__*.json")
+                   if not p.name.endswith(".atlas.json"))
+    assert len(jsons) == 1
+    # verbatim byte-exact
+    assert (sp / jsons[0]).read_bytes() == js
+    idx = json.loads((sp / "index.json").read_text())
+    assert len(idx) == 1
+    assert idx[0]["group"] == "spine.Gargoyle"
+    assert idx[0]["animations"] == 3
+    # atlas sidecar exists
+    assert (sp / (jsons[0][:-5] + ".atlas.json")).exists()
+
+
+def test_extract_spine_no_skeletons(tmp_path):
+    reader = _FakeReader({"/g/x/scene.radium": b"not a spine scene at all"})
+    assert spine.extract_spine(reader, str(tmp_path)) == 0
+
+
+def test_extract_spine_no_radium(tmp_path):
+    reader = _FakeReader({"/g/readme.txt": b"hi"})
+    assert spine.extract_spine(reader, str(tmp_path)) == 0

--- a/tests/test_stern_textures.py
+++ b/tests/test_stern_textures.py
@@ -186,6 +186,56 @@ def test_parse_radium_images_none_in_plain_data():
     assert engine.parse_radium_images(b"\x00" * 4096) == []
 
 
+# ---- fmt == 4 (BC1/DXT1): descriptor, block-size law, inline image ----------
+
+def test_parse_texture_descriptor_reads_fmt4():
+    data = _radium_with("31.asset", 256, 128, 4)
+    assert engine.parse_texture_descriptor(data, "31.asset") == (256, 128, 4)
+
+
+def _embed_radium_image_bc1(tex_w, tex_h, fill=(20, 200, 90, 255), junk=8):
+    """Build a radium fragment with one inline BC1/DXT1 image (fmt == 4).
+
+    The length law is half of BC3: padded(W)*padded(H) // 2."""
+    from pinball_decryptor.plugins.stern import dds
+    import struct
+    pw = ((tex_w + 3) // 4) * 4
+    ph = ((tex_h + 3) // 4) * 4
+    img = np.empty((ph, pw, 4), dtype=np.uint8)
+    img[:] = fill
+    raw = dds.encode_bc1(img)
+    assert len(raw) == pw * ph // 2
+    blob = (b"\x7f" * junk
+            + struct.pack("<II", tex_w, tex_h)          # dispW, dispH
+            + struct.pack("<I", 0x80000003)             # handle
+            + struct.pack("<II", tex_w, tex_h)          # texW, texH
+            + struct.pack("<I", 4)                      # format = DXT1/BC1
+            + struct.pack("<II", 0, 0)
+            + struct.pack("<I", len(raw))               # length
+            + raw)
+    data_off = junk + 4 * 9
+    return blob, data_off, len(raw), pw, ph
+
+
+def test_parse_radium_images_finds_embedded_dxt1():
+    blob, data_off, length, pw, ph = _embed_radium_image_bc1(462, 66)
+    imgs = engine.parse_radium_images(blob)
+    assert len(imgs) == 1
+    im = imgs[0]
+    assert (im["data_off"], im["length"], im["pad_w"], im["pad_h"]) == (
+        data_off, length, pw, ph)
+    assert (im["tex_w"], im["tex_h"]) == (462, 66)
+    assert im["fmt"] == 4                                # BC1 detected
+
+
+def test_parse_radium_images_dxt1_rejects_bad_length():
+    blob, data_off, length, pw, ph = _embed_radium_image_bc1(16, 16)
+    bad = bytearray(blob)
+    import struct
+    struct.pack_into("<I", bad, data_off - 4, length + 4)
+    assert engine.parse_radium_images(bytes(bad)) == []
+
+
 # ---- radium-image replace: diff + size-neutral in-place writes --------------
 
 class _FakeRadiumReader:


### PR DESCRIPTION
Reworked per your review — dropped the grayscale `textures.py` and its
write-back, and rebuilt the two gaps you confirmed on the existing
`dds.py` BC3 path. Branch is rebased onto current `main`.

## 1. BC1 / DXT1 — `fmt = 4` (your "real gap")

`main` only handles `fmt = 5` (BC3/DXT5). `fmt = 4` is BC1: 8 bytes per
4×4 block, mode-switched on the `c0`/`c1` ordering — `c0 > c1` ⇒ 4-colour
opaque, `c0 <= c1` ⇒ 3-colour + 1-bit punch-through alpha (index 3 =
transparent black). Added `decode_bc1` / `encode_bc1` next to the BC3
pair in `dds.py`; both handle both modes and are size-neutral by
construction (exactly half of BC3), so the in-place patcher works
unchanged. `engine.py` now selects the codec by `fmt` across all three
paths: loose `.asset` leaves, inline radium images, and write-back.

## 2. Block-padded size law (bug fix, came out of the fmt=4 work)

The old `w * h == size` gate only matched multiple-of-4 dimensions and
silently dropped every non-mult-of-4 texture. Switched to the block law
— BC3 = `ceil(w/4)*ceil(h/4)*16`, BC1 = `*8`. On Elvira this recovers
1500 previously-dropped textures (1245 BC3 + 255 BC1); all 3763 scene
leaves now decode.

## 3. Spine 3.1.08 export (you said you'd love to take this)

`spine.py` extracts the Spine skeleton JSON that Spike 2 embeds verbatim
as a u64-length-prefixed string inside `scene.radium`, plus an atlas
sidecar and an `index.json` catalog. Wired into `extract_all` under the
existing images phase (no `manufacturer.py` phase changes), in its own
try/except so a failure can never abort the rest of the extract.

## Tests

- `test_stern_dds.py`: BC1 round-trip, mode-switch, punch-through alpha,
  gradient error, non-mult-of-4 dims, short-data rejection.
- `test_stern_textures.py`: `fmt = 4` descriptor parse + inline-image
  detection + length law.
- `test_stern_spine.py`: skeleton parse, atlas build, full extract.

126 stern tests pass.

Installers: added the `stern.spine` hidden-import to both build scripts.